### PR TITLE
block Web App resources (keybindings etc)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
+    "webNavigation",
     "https://twitter.com/*",
     "https://tweetdeck.twitter.com/*",
     "https://abs.twimg.com/*",

--- a/src/background.js
+++ b/src/background.js
@@ -54,3 +54,60 @@ chrome.webRequest.onBeforeRequest.addListener(
     {urls: ["https://tweetdeck.twitter.com/*"]},
     ["blocking"]
 );
+
+const isFirefox = typeof browser !== "undefined";
+
+// Store the URL of the tab that initiated the request.
+let urls = {};
+
+const flushCache = chrome.webRequest.handlerBehaviorChanged;
+
+chrome.webNavigation.onCommitted.addListener(
+    function (details) {
+        // Flushes in-memory cache when moving from other twitter.com sites to TweetDeck,
+        // because if cache hits, `onBeforeRequest` event won't be called (and thus we can't block unwanted requests below).
+        // Only needed in Chrome. See: https://developer.chrome.com/docs/extensions/reference/webRequest/#caching
+        if (
+            !isFirefox &&
+            urls[details.tabId]?.[details.frameId].startsWith(
+                "https://twitter.com/",
+            ) &&
+            details.transitionType !== "reload" &&
+            details.url === "https://twitter.com/i/tweetdeck"
+        ) {
+            flushCache();
+        // Update stored URL
+        }
+        if (details.tabId === -1 || details.frameId !== 0) {
+            return;
+        }
+        if (!urls.hasOwnProperty(details.tabId)) {
+            urls[details.tabId] = {};
+        }
+        urls[details.tabId][details.frameId] = details.url;
+    },
+    { url: [{ hostSuffix: "twitter.com" }] },
+);
+
+// Block requests for files related to Web App, except for main.{random}.js (which may be needed for API connection)
+chrome.webRequest.onBeforeRequest.addListener(
+    function (details) {
+        try {
+            let parsedUrl = new URL(details.url);
+            let path = parsedUrl.pathname;
+            // want to use details.originUrl but it's not available in Chrome
+            let requestFrom = urls[details.tabId][details.frameId];
+            if (
+                path.startsWith("/responsive-web/client-web/") &&
+                !path.startsWith("/responsive-web/client-web/main") &&
+                requestFrom === "https://twitter.com/i/tweetdeck"
+            ) {
+                return {
+                    cancel: true,
+                };
+            }
+        } catch (e) {}
+    },
+    { urls: ["https://abs.twimg.com/*"] },
+    ["blocking"],
+);


### PR DESCRIPTION
- Block requests for files related to Web App, except for `main.{random}.js` (which may be needed for API connection)
  - may close #41 
- Ensure that the above blocking is performed even when navigating from Web App, within the same tab (Chrome-specific issue)