### PR TITLE
block another Web App resource path

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -98,7 +98,8 @@ chrome.webRequest.onBeforeRequest.addListener(
             // want to use details.originUrl but it's not available in Chrome
             let requestFrom = urls[details.tabId][details.frameId];
             if (
-                path.startsWith("/responsive-web/client-web/") &&
+                (path.startsWith("/responsive-web/client-web-legacy/") ||
+                    path.startsWith("/responsive-web/client-web/")) &&
                 requestFrom === "https://twitter.com/i/tweetdeck"
             ) {
                 return {


### PR DESCRIPTION
Looks like the ~~new~~ some versions of Web App uses different path for resources.

1. `/responsive-web/client-web`
![old](https://github.com/dimdenGD/OldTweetDeck/assets/57034105/12af961e-8a8f-4196-b87b-af0aeb54c6e7)

2. `/responsive-web/client-web-legacy/`
![new](https://github.com/dimdenGD/OldTweetDeck/assets/57034105/8ba4dad3-501c-4c2e-8fa9-f45c53da6f35)

Which version is used **depends on situation** (The former img is taken from my sub account on Chrome, while the latter is from main on Firefox, both cache cleared, at the same time), so we have to block both for now.