### PR TITLE
[Japanese] Fix: korean readme link 📄

### DIFF
--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -7,7 +7,7 @@
 
 ### 他の言語での説明
 [English README](/README.md)  
-[한국어 README](docs/README_KO.md)
+[한국어 README](/docs/README_KO.md)
 
 ## インストール方法
 
@@ -248,4 +248,4 @@ manifest V2 で作り直し外部サーバーを必要としないように変�
 [@katabame](https://twitter.com/katabame)  
 以下の時点の内容を基に翻訳されています。  
 * README: commit [294882a](https://github.com/dimdenGD/OldTweetDeck/commit/294882a3d5de029b2b1158d331c8549c941e34ac)  
-* 更新履歴: release/tag [v3.4.0](https://github.com/dimdenGD/OldTweetDeck/releases/tag/v3.4.0)
+* 更新履歴: release/tag [v3.5.5](https://github.com/dimdenGD/OldTweetDeck/releases/tag/v3.5.5)


### PR DESCRIPTION
fixed Korean readme's link url and release tag version