### PR TITLE
fixed NewTweet Column sizing

### DIFF
--- a/files/bundle.css
+++ b/files/bundle.css
@@ -39467,7 +39467,7 @@ html.dark .Drawer-neighbor {
 html.dark .Drawer {
     display: flex;
     flex-direction: column;
-    width: 608px;
+    /* width: 608px; */
     background-color: #fff;
 }
 html.dark .Drawer:not([dir="rtl"]) {


### PR DESCRIPTION
# Reasons
Of the CSS applied to Columns, `html.dark .Drawer` width must also be disabled

Fix problem with elements being stretched beyond the display area.

