### PR TITLE
fix gifs being the entire height of a column

### DIFF
--- a/files/bundle.css
+++ b/files/bundle.css
@@ -12933,6 +12933,7 @@ h6 {
 .tweet-detail-media .media-item-gif {
     -webkit-transform: none;
     transform: none;
+    height: auto;
 }
 .tweet-detail-media .media-item,
 .tweet-detail-media .media-preview {


### PR DESCRIPTION
when you click on a tweet with a gif, the gif enlarges itself to the entire column