### PR TITLE
block jot, and generally try to hide more

### DIFF
--- a/files/bundle.js
+++ b/files/bundle.js
@@ -34300,7 +34300,7 @@ document.body.addEventListener("click", function (e) {
                                 },
                             },
                             t = TD.net.ajax.request(
-                                TD.config.twitter_api_base + "/1.1/help/settings.json?meow_post",
+                                TD.config.twitter_api_base + "/1.1/help/settings.json",
                                 {
                                     method: "GET",
                                     params: (0, c.default)(e),

--- a/ruleset.json
+++ b/ruleset.json
@@ -76,5 +76,72 @@
             "urlFilter": "*://tweetdeck.twitter.com/*",
             "resourceTypes": ["main_frame", "sub_frame", "stylesheet", "script", "image", "font", "xmlhttprequest", "other"]
         }
+    },
+    {
+        "id": 6,
+        "priority": 1,
+        "action": {
+            "type": "modifyHeaders",
+            "requestHeaders": [
+                {
+                    "header": "x-twitter-client-version",
+                    "operation": "remove"
+                }
+            ]
+        },
+        "condition": {
+            "urlFilter": "https://api.x.com/*",
+            "resourceTypes": ["main_frame", "sub_frame", "stylesheet", "script", "image", "font", "xmlhttprequest", "other"]
+        }
+    },
+    {
+        "id": 7,
+        "priority": 1,
+        "action": {
+            "type": "modifyHeaders",
+            "requestHeaders": [
+                {
+                    "header": "x-twitter-client-version",
+                    "operation": "remove"
+                }
+            ]
+        },
+        "condition": {
+            "urlFilter": "https://api.twitter.com/*",
+            "resourceTypes": ["main_frame", "sub_frame", "stylesheet", "script", "image", "font", "xmlhttprequest", "other"]
+        }
+    },
+    {
+        "id": 8,
+        "priority": 1,
+        "action": {
+            "type": "block"
+        },
+        "condition": {
+            "urlFilter": "https://twitter.com/i/jot",
+            "resourceTypes": ["main_frame", "sub_frame", "stylesheet", "script", "image", "font", "xmlhttprequest", "other"]
+        }
+    },
+    {
+        "id": 9,
+        "priority": 1,
+        "action": {
+            "type": "block"
+        },
+        "condition": {
+            "urlFilter": "https://x.com/i/otdstub",
+            "resourceTypes": ["main_frame", "sub_frame", "stylesheet", "script", "image", "font", "xmlhttprequest", "other"]
+        }
+    },
+    {
+        "id": 10,
+        "priority": 1,
+        "action": {
+            "type": "block"
+        },
+        "condition": {
+            "urlFilter": "https://twitter.com/i/otdstub",
+            "resourceTypes": ["main_frame", "sub_frame", "stylesheet", "script", "image", "font", "xmlhttprequest", "other"]
+        }
     }
 ]

--- a/src/background.js
+++ b/src/background.js
@@ -65,6 +65,27 @@ chrome.webRequest.onBeforeRequest.addListener(
     ["blocking"]
 );
 
+chrome.webRequest.onBeforeRequest.addListener(
+    function() {
+        return {
+            cancel: true
+        }
+    },
+    {urls: ["https://twitter.com/i/jot", "https://twitter.com/i/otdstub", "https://x.com/i/otdstub"]},
+    ["blocking"]
+);
+
+chrome.webRequest.onBeforeRequest.addListener(
+    function(details) {
+        let headers = details.requestHeaders.filter(header => header.name.toLowerCase() !== 'x-twitter-client-version');
+        return {
+            requestHeaders: headers
+        }
+    },
+    {urls: ["https://api.twitter.com/*", "https://api.x.com/*"]},
+    ["blocking"]
+);
+
 const isFirefox = typeof browser !== "undefined";
 
 // Store the URL of the tab that initiated the request.

--- a/src/interception.js
+++ b/src/interception.js
@@ -10,6 +10,20 @@ const generateID = () => {
     return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 }
 
+let originalCookie = Document.prototype.__lookupSetter__('cookie')
+
+Object.defineProperty(document, 'cookie', {
+    configurable: true,
+    enumerable: true,
+    get() {
+        return Document.prototype.__lookupGetter__('cookie').call(document);
+    },
+    set(value) {
+        if (value.trim().toLowerCase().startsWith('tweetdeck_version=')) return;
+        originalCookie.call(document, value)
+    }
+})
+
 let verifiedUser = localStorage.OTDverifiedUser ? JSON.parse(localStorage.OTDverifiedUser) : null;
 let feeds = localStorage.OTDfeeds ? JSON.parse(localStorage.OTDfeeds) : {};
 let columns = localStorage.OTDcolumns ? JSON.parse(localStorage.OTDcolumns) : {};
@@ -2082,7 +2096,7 @@ const proxyRoutes = [
         path: "/1.1/tweetdeck/clients/blackbird/all",
         method: "GET",
         beforeRequest: (xhr) => {
-            xhr.modUrl = `https://api.${location.hostname}/1.1/help/settings.json?meow`;
+            xhr.modUrl = `https://api.${location.hostname}/1.1/help/settings.json`;
         },
         afterRequest: (xhr) => {
             const state = {
@@ -2135,7 +2149,7 @@ const proxyRoutes = [
             },
         },
         beforeRequest: (xhr) => {
-            xhr.modUrl = `https://api.${location.hostname}/1.1/help/settings.json?meow_push`;
+            xhr.modUrl = `https://${location.hostname}/i/otdstub?meow_push`;
             xhr.modMethod = "GET";
         },
         beforeSendBody: (xhr, body) => {
@@ -2167,7 +2181,7 @@ const proxyRoutes = [
             },
         },
         beforeRequest: (xhr) => {
-            xhr.modUrl = `https://api.${location.hostname}/1.1/help/settings.json?meow_feeds_push`;
+            xhr.modUrl = `https://${location.hostname}/i/otdstub?meow_feeds_push`;
             xhr.modMethod = "GET";
         },
         beforeSendBody: (xhr, body) => {
@@ -2197,7 +2211,7 @@ const proxyRoutes = [
             },
         },
         beforeRequest: (xhr) => {
-            xhr.modUrl = `https://api.${location.hostname}/1.1/help/settings.json?meow_columns_push`;
+            xhr.modUrl = `https://${location.hostname}/i/otdstub?meow_columns_push`;
             xhr.modMethod = "GET";
         },
         beforeSendBody: (xhr, body) => {
@@ -2293,6 +2307,31 @@ const proxyRoutes = [
             });
         }
     },
+    // stubs
+    {
+        path: '/web/dist/version.json',
+        method: 'GET',
+        beforeRequest: (xhr) => {
+            xhr.modUrl = `https://${location.hostname}/i/otdstub?meow_version`
+        },
+        afterRequest: () => {
+            return JSON.stringify({ version: '4.0.220811153004', minimum: '4.0.190610153508' });
+        }
+    },
+    {
+        path: '/1.1/help/configuration.json',
+        method: 'GET',
+        beforeRequest: (xhr) => {
+            xhr.modUrl = `https://${location.hostname}/i/otdstub?meow_configuration`
+        }
+    },
+    {
+        path: '/1.1/tweetdeck/dataminr/authtoken',
+        method: 'GET',
+        beforeRequest: (xhr) => {
+            xhr.modUrl = `https://${location.hostname}/i/otdstub?meow_dataminr`
+        }
+    }
 ];
 
 // wrap the XMLHttpRequest


### PR DESCRIPTION
since the banwave incident, otd should probably be more discreet... definitely still not bulletproof, but precautions are good

changes:
block /i/jot analytics calls (which identified the client as tweetdeck blackbird)
block tweetdeck_version cookie from being set
block x-twitter-client-version in remaining places
stub useless/dead endpoints where possible
remove meows on real api calls :(